### PR TITLE
Increase postgresql shared_buffers

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -14,4 +14,9 @@ nyaapantsu_torrent_tablename: torrents
 # nyaapantsu_torrent_tablename: torrents_sukebei
 nyaapantsu_max_open_files: 200000
 nyaapantsu_jvm_heapsize_gb: 8
+nyaapantsu_postgresql_shared_buffers_gb: 8
+nyaapantsu_postgresql_effective_cache_size: 16
+# Used for maintenance operation such as VACUUM. Should be higher
+# than work_mem
+nyaapantsu_postgresql_maintenance_work_mem_mb: 256
 # vim: ft=yaml

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -110,7 +110,7 @@ max_connections = 100			# (change requires restart)
 
 # - Memory -
 
-shared_buffers = 128MB			# min 128kB
+shared_buffers = {{ nyaapantsu_postgresql_shared_buffers_gb }}GB			# min 128kB
 					# (change requires restart)
 #huge_pages = try			# on, off, or try
 					# (change requires restart)
@@ -120,7 +120,7 @@ shared_buffers = 128MB			# min 128kB
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
 #work_mem = 4MB				# min 64kB
-#maintenance_work_mem = 64MB		# min 1MB
+maintenance_work_mem = {{ nyaapantsu_postgresql_maintenance_work_mem_mb }}MB		# min 1MB
 #replacement_sort_tuples = 150000	# limits use of replacement selection sort
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB


### PR DESCRIPTION
So we have 10gb for pgpool, 8gb for postgresql and 8gb for ES. The rest will be used by the application and `Lucene will happily gobble up whatever is left over.

Thoughts ?