### PR TITLE
Comma separate language on indexing

### DIFF
--- a/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -23,6 +23,14 @@ settings:
           - underscore_to_space
           - dash_to_underscore
 
+      nyaapantsu_language_analyzer:
+        tokenizer: comma_separator_tokenizer
+
+    tokenizer:
+      comma_separator_tokenizer:
+        type: pattern
+        pattern: ","
+
     filter:
       e_ngram_filter:
         type: edge_ngram
@@ -79,7 +87,7 @@ mappings:
         type: long
       language:
         type: text
-        analyzer: simple
+        analyzer: nyaapantsu_language_analyzer
       seeders:
         type: long
       leechers:


### PR DESCRIPTION
This is for the refactor branch of nyaa.
```bash
$ curl -XGET 'localhost:9200/nyaapantsu/_analyze?pretty' -H 'Content-Type: application/json' -d '{"analyzer" : "nyaapantsu_language_analyzer","text" : ["fr-fr,en-us,jp-ja"]}'
{
  "tokens" : [
    {
      "token" : "fr-fr",
      "start_offset" : 0,
      "end_offset" : 5,
      "type" : "word",
      "position" : 0
    },
    {
      "token" : "en-us",
      "start_offset" : 6,
      "end_offset" : 11,
      "type" : "word",
      "position" : 1
    },
    {
      "token" : "jp-ja",
      "start_offset" : 12,
      "end_offset" : 17,
      "type" : "word",
      "position" : 2
    }
  ]
}
```