### PR TITLE
Fix ES not restarting and fix indexing deleted torrents

### DIFF
--- a/ansible/roles/elasticsearch/templates/elasticsearch.override.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.override.j2
@@ -1,6 +1,3 @@
 [Service]
 LimitNOFILE=
 LimitNOFILE={{ nyaapantsu_max_open_files }}
-
-LimitMEMLOCK=
-LimitMEMLOCK=infinity


### PR DESCRIPTION
Removed mlockall. My hypotheses is something is taking too much memory, the system has to stop ES because it's taking the most memory, ES tries to restart but it can't because mlockall.

To make sure mlockall is not set, run this command:
```bash
curl -XGET 'localhost:9200/_nodes?filter_path=**.mlockall'
```