### PR TITLE
Improve resolution, quotes and zero trimming

### DIFF
--- a/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -53,8 +53,8 @@ settings:
 
       trim_zeros:
         type: pattern_replace
-        pattern: "(\\s)+0+([123456789])"
-        replacement: "$1 $2"
+        pattern: "\\b0+([123456789])"
+        replacement: "$1"
 
       resolution:
         type: pattern_replace

--- a/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -48,7 +48,7 @@ settings:
     char_filter:
       dash_to_underscore:
         type: pattern_replace
-        pattern: "([^\\s]+)-(?=[^\\s]+)"
+        pattern: "\\b([^\\s]{1,3})-(?=[^\\s]{1,3})"
         replacement: "$1_"
 
       trim_zeros:

--- a/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -11,7 +11,10 @@ settings:
           - lowercase
         char_filter:
           - underscore_to_space
+          - trim_zeros
+          - resolution
           - dash_to_underscore
+          - remove_quotes
 
       nyaapantsu_index_analyzer:
         tokenizer: standard
@@ -21,7 +24,10 @@ settings:
           - e_ngram_filter
         char_filter:
           - underscore_to_space
+          - trim_zeros
+          - resolution
           - dash_to_underscore
+          - remove_quotes
 
       nyaapantsu_language_analyzer:
         tokenizer: comma_separator_tokenizer
@@ -42,6 +48,21 @@ settings:
         type: pattern_replace
         pattern: "([^\\s]+)-(?=[^\\s]+)"
         replacement: "$1_"
+
+      trim_zeros:
+        type: pattern_replace
+        pattern: "(\\s)+0+([123456789])"
+        replacement: "$1 $2"
+
+      resolution:
+        type: pattern_replace
+        pattern: "(\\d+)[xX](\\d+)"
+        replacement: "$1 $2"
+
+      remove_quotes:
+        type: pattern_replace
+        pattern: "['`]"
+        replacement: ""
 
       underscore_to_space:
         type: mapping

--- a/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -15,6 +15,7 @@ settings:
           - resolution
           - dash_to_underscore
           - remove_quotes
+          - resolution_fix
 
       nyaapantsu_index_analyzer:
         tokenizer: standard
@@ -28,6 +29,7 @@ settings:
           - resolution
           - dash_to_underscore
           - remove_quotes
+          - resolution_fix
 
       nyaapantsu_language_analyzer:
         tokenizer: comma_separator_tokenizer
@@ -68,6 +70,16 @@ settings:
         type: mapping
         mappings:
           - "_ => \\u0020"
+
+      # This fixes the following (and similar) scenario:
+      # Searching for episode 19 for a series gives all episode of that series
+      # because it had 1920 x 1080 resolution
+      # The random string below must not be too long for now because the n-gram
+      # accepts only 16 characters
+      resolution_fix:
+        type: pattern_replace
+        pattern: "\\b(1920|1280|1024|1080p?|900p?|720p?|576p?|480p?)\\b"
+        replacement: "c0ca98a77$1"
 
   index:
     number_of_shards: 1


### PR DESCRIPTION
Improved search quite a bit. Mostly zero trimming, resolution and ' searches.

The following example uses this entry:
```json
'{"name":"[Ohys-Raws] Knight`s & Magic - 08 (AT-X 1280x720 x264 AAC).mp4"}'
```
### Searching for episode 8

*Before*
```bash
$ curl -XGET 'http://localhost:9200/nyaapantsu_v1/_search?pretty' -d '{"query":{"query_string":{"fields":["name"],"query":"8","analyzer":"nyaapantsu_search_analyzer","default_operator":"and"}}}'
{
  "took" : 2,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "hits" : {
    "total" : 0,
    "max_score" : null,
    "hits" : [ ]
  }
}
```

*Now*
```bash
$ curl -XGET 'http://localhost:9200/nyaapantsu_v6/_search?pretty' -d '{"query":{"query_string":{"fields":["name"],"query":"8","analyzer":"nyaapantsu_search_analyzer","default_operator":"and"}}}'
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "hits" : {
    "total" : 1,
    "max_score" : 0.4179422,
    "hits" : [
      {
        "_index" : "nyaapantsu_v6",
        "_type" : "torrents",
        "_id" : "AV4AxB3khGpP72d3facC",
        "_score" : 0.4179422,
        "_source" : {
          "name" : "[Ohys-Raws] Knight`s & Magic - 08 (AT-X 1280x720 x264 AAC).mp4"
        }
      }
    ]
  }
}

```

### Searching for resolution 720

*Before*
```bash
$ curl -XGET 'http://localhost:9200/nyaapantsu_v1/_search?pretty' -d '{"query":{"query_string":{"fields":["name"],"query":"720","analyzer":"nyaapantsu_search_analyzer","default_operator":"and"}}}'
{
  "took" : 9,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "hits" : {
    "total" : 0,
    "max_score" : null,
    "hits" : [ ]
  }
}
```

*Now*
```bash
$ curl -XGET 'http://localhost:9200/nyaapantsu_v6/_search?pretty' -d '{"query":{"query_string":{"fields":["name"],"query":"720","analyzer":"nyaapantsu_search_analyzer","default_operator":"and"}}}'
{
  "took" : 3,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "hits" : {
    "total" : 1,
    "max_score" : 0.4179422,
    "hits" : [
      {
        "_index" : "nyaapantsu_v6",
        "_type" : "torrents",
        "_id" : "AV4AxB3khGpP72d3facC",
        "_score" : 0.4179422,
        "_source" : {
          "name" : "[Ohys-Raws] Knight`s & Magic - 08 (AT-X 1280x720 x264 AAC).mp4"
        }
      }
    ]
  }
}
```

### Searching for words with ' or ` in it

*Before*
```bash
$ curl -XGET 'http://localhost:9200/nyaapantsu_v1/_search?pretty' -d '{"query":{"query_string":{"fields":["name"],"query":"knights","analyzer":"nyaapantsu_search_analyzer","default_operator":"and"}}}'
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "hits" : {
    "total" : 0,
    "max_score" : null,
    "hits" : [ ]
  }
}
```

*Now*
```bash
$ curl -XGET 'http://localhost:9200/nyaapantsu_v6/_search?pretty' -d '{"query":{"query_string":{"fields":["name"],"query":"knights","analyzer":"nyaapantsu_search_analyzer","default_operator":"and"}}}'
{
  "took" : 4,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "hits" : {
    "total" : 1,
    "max_score" : 0.4179422,
    "hits" : [
      {
        "_index" : "nyaapantsu_v6",
        "_type" : "torrents",
        "_id" : "AV4AxB3khGpP72d3facC",
        "_score" : 0.4179422,
        "_source" : {
          "name" : "[Ohys-Raws] Knight`s & Magic - 08 (AT-X 1280x720 x264 AAC).mp4"
        }
      }
    ]
  }
}
```

### Next

There are still a few things that annoy me. Searching for episode 7 of a serie (ie: name:07 or name:7) will find all episode with resolution 720p, because of the ngram filter. 
A possible hacky fix (?) could be to append a long string (ie: myverylongstringresolution$resolution) for every number that are common resolution. So we'd have a pattern match that looks something like:
```yaml
    append_resolution_string:                                                                
          type: pattern_replace                                                    
          pattern: "(1920|1366|1280|1024|640|1080|720|480)"
          replacement: "myverylongstringresolution$1"  
```
Now searching for "07" or "7" wouldn't find 720p episodes.
Searching for resolutions would still work because the same pattern would be applied to the search analyzer.


The other thing that annoys me is that searching for "ohys raws" doesn't give any result.
This is because "Ohys-raws" gets transformed to "ohys_raws". This was done for the k-on! search.
I'm not sure what we should do in this case. A solution (maybe) could to do the k-on! kind of fix for words with 3 or less letters. So "aaa-bbb" would be transformed to "aaa_bbb", but "aaaa-bbbb" wouldn't.

What do you guys think ?

EDIT: I went and implemented a fix for the two problem described above. Now the one problem I don't like is searching for "boku no hero 7" gives the following result: '[kBaraka] Boku no Hero Academia (S2) - 24 [785EDE92].mkv ' because of the hash at the end. I don't think it's much of a problem, still kinda annoying.