### PR TITLE
Fix unwanted result from crc32

### DIFF
--- a/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -78,15 +78,19 @@ settings:
       # because it had 1920 x 1080 resolution
       # The random string below must not be too long for now because the n-gram
       # accepts only 16 characters
+      # Prepending arabic symbol to avoid conflicts
       resolution_fix:
         type: pattern_replace
         pattern: "\\b(1920|1280|1024|1080p?|900p?|720p?|576p?|480p?)\\b"
-        replacement: "c0ca98a77$1"
+        replacement: "تresoluti$1"
 
+      # The random string below must not be too long for now because the n-gram
+      # accepts only 16 characters
+      # Prepending arabic symbol to avoid conflicts
       crc32_fix:
         type: pattern_replace
         pattern: "\\b(\\p{XDigit}{8})\\b"
-        replacement: "thecrc32$1"
+        replacement: "بcrc32$1"
 
   index:
     number_of_shards: 1


### PR DESCRIPTION
Now searching for 'boku no hero academia 7' won't match '[PuyaSubs!!] Boku no Hero Academia S2 - 33 [720p][79AE0A59].mkv' because of the crc32 79AE0A59.

However, we can still search for the full crc32 if anyone ever do that.